### PR TITLE
Add matplotlib visualization of failed login attempts

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -2,6 +2,7 @@ import re
 import argparse
 from collections import defaultdict
 import pandas as pd
+import matplotlib.pyplot as plt
 
 LOG_PATH = "logs/sample_auth.log"
 
@@ -29,9 +30,33 @@ def export_to_csv(ip_failures, filename="failed_logins.csv"):
     df.to_csv(filename, index=False)
     print(f"\n Exported to {filename}")
 
+def plot_failed_logins(ip_failures):
+    ips = list(ip_failures.keys())
+    attempts = list(ip_failures.values())
+
+    # Sort for visual clarity
+    ips, attempts = zip(*sorted(zip(ips, attempts), key=lambda x: x[1], reverse=True))
+
+    plt.figure(figsize=(10, 6))
+    bars = plt.bar(ips, attempts)
+    plt.title("Failed SSH Login Attempts by IP")
+    plt.xlabel("IP Address")
+    plt.ylabel("Number of Failed Attempts")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+
+    for bar in bars:
+        height = bar.get_height()
+        plt.annotate(f'{height}', xy=(bar.get_x() + bar.get_width() / 2, height),
+                     xytext=(0, 3), textcoords="offset points", ha='center', fontsize=8)
+        
+        plt.savefig("failed_logins_chart.png")
+        plt.show()
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyze log file for failed SSH login attempts.")
     parser.add_argument("--export", action="store_true", help="Export results to CSV")
+    parser.add_argument("--plot", action="store_true", help="Plot results as bar chart")
 
     args = parser.parse_args()
 
@@ -40,3 +65,5 @@ if __name__ == "__main__":
 
     if args.export:
         export_to_csv(failures)
+    if args.plot:
+        plot_failed_logins(failures)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-# No external libraries needed yet
-# Future suggestions:
 matplotlib>=3.7.0   # for visualization IP counts
 pandas>=2.0.0       # for CSV/JSON export and analysis


### PR DESCRIPTION
### Summary

This PR adds a bar chart visualization to display the number of failed SSH login attempts per IP address using `matplotlib`.

### What's New

- Introduced a new `--plot` command-line flag
- Added `plot_failed_logins()` function using `matplotlib.pyplot`
- Sorted IPs by number of failures for clearer visual output
- Saves a chart as `failed_logins_chart.png` and also displays it interactively
- Updated `requirements.txt` to include `matplotlib`

### How to Use

```bash
python3 analyzer.py --plot
